### PR TITLE
Remove hard-coded check_http target.

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -191,7 +191,7 @@ class nagios::server::config (
   nagios_command { 'Check HTTP nonroot custom port':
     ensure       => 'present',
     command_name => 'check_http_nonroot_custom_port',
-    command_line => '/usr/lib/nagios/plugins/check_http -I $HOSTADDRESS$ -H $ARG1$ -u $ARG2$ -p $ARG3$  --onredirect=sticky -e 200,302',
+    command_line => '/usr/lib/nagios/plugins/check_http -H $ARG1$ -u $ARG2$ -p $ARG3$  --onredirect=sticky -e 200,302',
     target       => '/etc/nagios3/conf.d/puppet/command_nagios.cfg',
     notify       => Exec['rechmod'],
   }
@@ -199,7 +199,7 @@ class nagios::server::config (
   nagios_command { 'Check HTTPS nonroot custom port':
     ensure       => 'present',
     command_name => 'check_https_nonroot_custom_port',
-    command_line => '/usr/lib/nagios/plugins/check_http -S --sni -I $HOSTADDRESS$ -H $ARG1$ -u $ARG2$ -p $ARG3$  --onredirect=sticky -e 200,302',
+    command_line => '/usr/lib/nagios/plugins/check_http -S --sni -H $ARG1$ -u $ARG2$ -p $ARG3$  --onredirect=sticky -e 200,302',
     target       => '/etc/nagios3/conf.d/puppet/command_nagios.cfg',
     notify       => Exec['rechmod'],
   }
@@ -207,7 +207,7 @@ class nagios::server::config (
   nagios_command { 'Check HTTP custom string nonroot custom port':
     ensure       => 'present',
     command_name => 'check_http_custom_string_nonroot_custom_port',
-    command_line => '/usr/lib/nagios/plugins/check_http -I $HOSTADDRESS$ -H $ARG1$ -u $ARG2$ -p $ARG3$ -s $ARG4$ --onredirect=sticky',
+    command_line => '/usr/lib/nagios/plugins/check_http -H $ARG1$ -u $ARG2$ -p $ARG3$ -s $ARG4$ --onredirect=sticky',
     target       => '/etc/nagios3/conf.d/puppet/command_nagios.cfg',
     notify       => Exec['rechmod'],
   }
@@ -215,7 +215,7 @@ class nagios::server::config (
   nagios_command { 'Check HTTPS custom string nonroot custom port':
     ensure       => 'present',
     command_name => 'check_https_custom_string_nonroot_custom_port',
-    command_line => '/usr/lib/nagios/plugins/check_http -S --sni -I $HOSTADDRESS$ -H $ARG1$ -u $ARG2$ -p $ARG3$ -s $ARG4$ --onredirect=sticky',
+    command_line => '/usr/lib/nagios/plugins/check_http -S --sni -H $ARG1$ -u $ARG2$ -p $ARG3$ -s $ARG4$ --onredirect=sticky',
     target       => '/etc/nagios3/conf.d/puppet/command_nagios.cfg',
     notify       => Exec['rechmod'],
   }


### PR DESCRIPTION
There's great utility in monitoring hosts other than the host running nagios itself.
For example, the case where a nogios server monitors several remote HTTP(S) webservers.
Since -H works fine with IP addresses and hostnames alike, removing -i $HOSTADDRESS$
only increases the versatility of the service.